### PR TITLE
stairs command line utility

### DIFF
--- a/bin/stairs
+++ b/bin/stairs
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+
+require "optparse"
+require "stairs"
+
+Stairs.configure do |config|
+  OptionParser.new do |options|
+    options.banner = "Usage: stairs [options]"
+
+    options.on("--use-defaults", "Use defaults when available") do |value|
+      config.use_defaults = value
+    end
+  end.parse!
+end
+
+Stairs::Runner.new.run!

--- a/lib/stairs.rb
+++ b/lib/stairs.rb
@@ -10,6 +10,7 @@ module Stairs
   autoload :Configuration, "stairs/configuration"
   autoload :InteractiveConfiguration, "stairs/interactive_configuration"
   autoload :Util, "stairs/util"
+  autoload :Runner, "stairs/runner"
 
   class << self
     def configure
@@ -18,6 +19,10 @@ module Stairs
 
     def configuration
       @configuration ||= Configuration.new
+    end
+
+    def reset_configuration!
+      @configuration = Configuration.new
     end
   end
 end

--- a/lib/stairs/configuration.rb
+++ b/lib/stairs/configuration.rb
@@ -1,5 +1,10 @@
 module Stairs
   class Configuration
     attr_accessor :env_adapter
+    attr_accessor :use_defaults
+
+    def initialize
+      self.use_defaults = false
+    end
   end
 end

--- a/lib/stairs/interactive_configuration.rb
+++ b/lib/stairs/interactive_configuration.rb
@@ -4,9 +4,19 @@ module Stairs
     description "Interactive prompt for configuring Stairs"
 
     def run!
+      if Stairs.configuration.use_defaults
+        use_recommended_adapter!
+      else
+        configure_env_adapter
+      end
+    end
+
+    private
+
+    def configure_env_adapter
       choice prompt do |yes|
         if yes
-          Stairs.configuration.env_adapter = recommended_adapter.new
+          use_recommended_adapter!
         else
           choice "Which would you prefer?", adapter_names do |name|
             adapter_class = Stairs::EnvAdapters::ADAPTERS[name.to_sym]
@@ -16,7 +26,9 @@ module Stairs
       end
     end
 
-    private
+    def use_recommended_adapter!
+      Stairs.configuration.env_adapter = recommended_adapter.new
+    end
 
     def recommended_adapter
       @recommended_adapter ||= Stairs::EnvAdapters.recommended_adapter

--- a/lib/stairs/runner.rb
+++ b/lib/stairs/runner.rb
@@ -1,0 +1,8 @@
+module Stairs
+  class Runner
+    def run!
+      Stairs::InteractiveConfiguration.new.run!
+      Stairs::Script.new("setup.rb").run!
+    end
+  end
+end

--- a/lib/stairs/step.rb
+++ b/lib/stairs/step.rb
@@ -40,8 +40,12 @@ module Stairs
       prompt << " (leave blank for #{options[:default]})" if options[:default]
       prompt << ": "
 
-      Stairs::Util::CLI.collect(prompt.blue, required: required) ||
+      if Stairs.configuration.use_defaults && options[:default]
         options[:default]
+      else
+        Stairs::Util::CLI.collect(prompt.blue, required: required) ||
+          options[:default]
+      end
     end
 
     # Prompt user to make a choice

--- a/lib/stairs/tasks.rb
+++ b/lib/stairs/tasks.rb
@@ -7,8 +7,7 @@ module Stairs
     def install!
       desc "Setup the project"
       task :newb do
-        Stairs::InteractiveConfiguration.new.run!
-        Stairs::Script.new("setup.rb").run!
+        Stairs::Runner.new.run!
       end
     end
   end

--- a/spec/lib/configuration_spec.rb
+++ b/spec/lib/configuration_spec.rb
@@ -8,5 +8,16 @@ describe Stairs::Configuration do
       subject.env_adapter = "test"
       expect(subject.env_adapter).to eq "test"
     end
+
+    describe "use_defaults to automatically use default values" do
+      it "defaults to false" do
+        expect(subject.use_defaults).to eq false
+      end
+
+      it "allows for configuration" do
+        subject.use_defaults = true
+        expect(subject.use_defaults).to eq true
+      end
+    end
   end
 end

--- a/spec/lib/stairs/interactive_configuration_spec.rb
+++ b/spec/lib/stairs/interactive_configuration_spec.rb
@@ -32,5 +32,14 @@ describe Stairs::InteractiveConfiguration do
       follow_prompts("N", "dotenv") { subject.run! }
       expect(Stairs.configuration.env_adapter).to be_a Stairs::EnvAdapters::Dotenv
     end
+
+    context "when Stairs is configured to use defaults" do
+      before { Stairs.configuration.use_defaults = true }
+
+      it "uses the default adapter without asking" do
+        subject.run!
+        expect(Stairs.configuration.env_adapter).to be_a Stairs::EnvAdapters::Rbenv
+      end
+    end
   end
 end

--- a/spec/lib/stairs/runner_spec.rb
+++ b/spec/lib/stairs/runner_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+
+describe Stairs::Runner do
+  describe "#run!" do
+    let(:script_double) { double("script", run!: true) }
+
+    before do
+      # Stub things as to not block IO
+      Stairs::InteractiveConfiguration.any_instance.stub :run!
+      Stairs::Script.any_instance.stub :run!
+      Stairs::Script.stub(:new).and_return(script_double)
+    end
+
+    it "runs the interactive configuration" do
+      Stairs::InteractiveConfiguration.any_instance.should_receive(:run!)
+      subject.run!
+    end
+
+    it "runs the setup.rb script" do
+      Stairs::Script.should_receive(:new).with("setup.rb").and_return(script_double)
+      script_double.should_receive(:run!)
+
+      subject.run!
+    end
+  end
+end

--- a/spec/lib/stairs/step_spec.rb
+++ b/spec/lib/stairs/step_spec.rb
@@ -121,6 +121,24 @@ describe Stairs::Step do
       end
     end
 
+    context "Stairs is configured to use defaults automatically" do
+      before { Stairs.configuration.use_defaults = true }
+
+      context "but no default is provided" do
+        it "prompts for input as usual" do
+          follow_prompts "here ya go" do
+            expect(subject.provide("Gimme")).to eq "here ya go"
+          end
+        end
+      end
+
+      context "and a default is provided" do
+        it "returns the default without prompting" do
+          expect(subject.provide("Gimme", default: "adefault")).to eq "adefault"
+        end
+      end
+    end
+
     context "with a default" do
       def call_method
         subject.provide "Gimme", default: "adefault"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,7 +16,9 @@ RSpec.configure do |config|
   config.filter_run :focus
 
   config.include MockStdio
+  config.include ConfigurationHelper
 
   config.before(:all, &:silence_output)
   config.after(:all, &:enable_output)
+  config.after(:each, &:reset_configuration)
 end

--- a/spec/support/configuration_helper.rb
+++ b/spec/support/configuration_helper.rb
@@ -1,0 +1,5 @@
+module ConfigurationHelper
+  def reset_configuration
+    Stairs.reset_configuration!
+  end
+end


### PR DESCRIPTION
Run setup via `stairs` command line utility with support for
`--use-defaults` option to automatically accept the recommended
ENV adapter and use defaults for prompts when available.
