### PR TITLE
Adding db:test:prepare to README example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ setup :misc do
   env "CHECK_IT", provide("Cool check it value")
 end
 
-rake "db:setup"
+rake "db:setup db:test:prepare"
 
 finish "Just run rails s and sidekiq to get rolling!"
 ```


### PR DESCRIPTION
New apps should also add db:test:prepare, otherwise you can't run tests right
away.
